### PR TITLE
Let ssh figure out port/user if not specified so we don't override .ssh/config

### DIFF
--- a/attic/helpers.py
+++ b/attic/helpers.py
@@ -285,7 +285,7 @@ class Location:
             self.proto = m.group('proto')
             self.user = m.group('user')
             self.host = m.group('host')
-            self.port = m.group('port') and int(m.group('port')) or 22
+            self.port = m.group('port') and int(m.group('port')) or None
             self.path = m.group('path')
             self.archive = m.group('archive')
             return True
@@ -302,8 +302,6 @@ class Location:
             self.path = m.group('path')
             self.archive = m.group('archive')
             self.proto = self.host and 'ssh' or 'file'
-            if self.proto == 'ssh':
-                self.port = 22
             return True
         return False
 

--- a/attic/remote.py
+++ b/attic/remote.py
@@ -83,7 +83,14 @@ class RemoteRepository(object):
         if location.host == '__testsuite__':
             args = [sys.executable, '-m', 'attic.archiver', 'serve']
         else:
-            args = ['ssh', '-p', str(location.port), '%s@%s' % (location.user or getpass.getuser(), location.host), 'attic', 'serve']
+            args = ['ssh',]
+            if location.port:
+                args += ['-p', str(location.port)]
+            if location.user:
+                args.append('%s@%s' % (location.user, location.host))
+            else:
+                args.append('%s' % location.host)
+            args += ['attic', 'serve']
         self.p = Popen(args, bufsize=0, stdin=PIPE, stdout=PIPE)
         self.stdin_fd = self.p.stdin.fileno()
         self.stdout_fd = self.p.stdout.fileno()


### PR DESCRIPTION
If I specified a user or port for a host in my .ssh/config, and I haven't specified a different value on the attic command line, then I want the values in the .ssh/config used instead of 22 and the current user.
