### PR TITLE
Use lockf() instead of flock()

### DIFF
--- a/attic/cache.py
+++ b/attic/cache.py
@@ -58,8 +58,8 @@ class Cache(object):
     def open(self):
         if not os.path.isdir(self.path):
             raise Exception('%s Does not look like an Attic cache' % self.path)
-        self.lock_fd = open(os.path.join(self.path, 'README'), 'r+')
-        fcntl.flock(self.lock_fd, fcntl.LOCK_EX)
+        self.lock_fd = open(os.path.join(self.path, 'README'), 'a')
+        fcntl.lockf(self.lock_fd, fcntl.LOCK_EX)
         self.rollback()
         self.config = RawConfigParser()
         self.config.read(os.path.join(self.path, 'config'))

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -71,8 +71,8 @@ class Repository(object):
         self.path = path
         if not os.path.isdir(path):
             raise self.DoesNotExist(path)
-        self.lock_fd = open(os.path.join(path, 'config'), 'r')
-        fcntl.flock(self.lock_fd, fcntl.LOCK_EX)
+        self.lock_fd = open(os.path.join(path, 'config'), 'a')
+        fcntl.lockf(self.lock_fd, fcntl.LOCK_EX)
         self.config = RawConfigParser()
         self.config.read(os.path.join(self.path, 'config'))
         if self.config.getint('repository', 'version') != 1:


### PR DESCRIPTION
lockf() is generally considered more portable.
The major problem with flock() is that it does not work
on NFS files, making it impossible to create attic repositories
on NFS mounts.
