### PR TITLE
Fix for sorting files in 'data' dir when non-integer filenames exist

### DIFF
--- a/attic/repository.py
+++ b/attic/repository.py
@@ -295,9 +295,12 @@ class LoggedIO(object):
     def _segment_names(self, reverse=False):
         for dirpath, dirs, filenames in os.walk(os.path.join(self.path, 'data')):
             dirs.sort(key=int, reverse=reverse)
-            filenames.sort(key=int, reverse=reverse)
+            filenames.sort(key=lambda x: int(x) if x.isdigit() else 0, reverse=reverse)
             for filename in filenames:
-                yield int(filename), os.path.join(dirpath, filename)
+                try:
+                    yield int(filename), os.path.join(dirpath, filename)
+                except ValueError:
+                    pass
 
     def cleanup(self):
         """Delete segment files left by aborted transactions


### PR DESCRIPTION
On NFS it is possible that files named like '.nfsXXXXX' are created
when a file is removed while it is still opened by another process.
With this fix, all files under data/ with file names that are not integers
are ignored so that int() works as expected.
