### PR TITLE
Try a local installation of libcrypto

### DIFF
--- a/attic/crypto.py
+++ b/attic/crypto.py
@@ -6,6 +6,9 @@ from ctypes.util import find_library
 import struct
 
 libcrypto = cdll.LoadLibrary(find_library('crypto'))
+# If distro-provided libcrypto is too old, try a local installation
+if not hasattr(libcrypto, 'PKCS5_PBKDF2_HMAC'):
+    libcrypto = cdll.LoadLibrary('/usr/local/ssl/lib/libcrypto.so')
 # Default libcrypto on OS X is too old, try the brew version
 if not hasattr(libcrypto, 'PKCS5_PBKDF2_HMAC') and sys.platform == 'darwin':
     libcrypto = cdll.LoadLibrary('/usr/local/opt/openssl/lib/libcrypto.dylib')


### PR DESCRIPTION
If the distro-provided libcrypto is too old, then try a local
installation at /usr/local.

For example, this is needed to make attic run on Debian Squeeze,
which has an unsupported libcrypto (0.9.8), by also installing
a newer, supported version of libcrypto at /usr/local (e.g. with
the standard "./configure, make, make install" procedure)
