### PR TITLE
Add --dry-run option to prune.

### DIFF
--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -331,8 +331,11 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         for archive in keep:
             self.print_verbose('Keeping archive "%s"' % archive.name)
         for archive in to_delete:
-            self.print_verbose('Pruning archive "%s"', archive.name)
-            archive.delete(cache)
+            if args.dry_run:
+                self.print_verbose('Would prune     "%s"' % archive.name)
+            else:
+                self.print_verbose('Pruning archive "%s"' % archive.name)
+                archive.delete(cache)
         return self.exit_code
 
     helptext = {}
@@ -561,6 +564,9 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                                           description=self.do_prune.__doc__,
                                           epilog=prune_epilog)
         subparser.set_defaults(func=self.do_prune)
+        subparser.add_argument('-n', '--dry-run', dest='dry_run',
+                               default=False, action='store_true',
+                               help='do not change repository')
         subparser.add_argument('--keep-within', dest='within', type=str, metavar='WITHIN',
                                help='keep all archives within this time interval')
         subparser.add_argument('-H', '--keep-hourly', dest='hourly', type=int, default=0,

--- a/attic/testsuite/archiver.py
+++ b/attic/testsuite/archiver.py
@@ -253,10 +253,16 @@ class ArchiverTestCase(ArchiverTestCaseBase):
         self.attic('init', self.repository_location)
         self.attic('create', self.repository_location + '::test1', src_dir)
         self.attic('create', self.repository_location + '::test2', src_dir)
-        self.attic('prune', self.repository_location, '--daily=2')
+        output = self.attic('prune', '-v', '--dry-run', self.repository_location, '--keep-daily=2')
+        self.assert_in('Keeping archive "test2"', output)
+        self.assert_in('Would prune     "test1"', output)
         output = self.attic('list', self.repository_location)
-        assert 'test1' not in output
-        assert 'test2' in output
+        self.assert_in('test1', output)
+        self.assert_in('test2', output)
+        self.attic('prune', self.repository_location, '--keep-daily=2')
+        output = self.attic('list', self.repository_location)
+        self.assert_not_in('test1', output)
+        self.assert_in('test2', output)
 
     def test_usage(self):
         self.assert_raises(SystemExit, lambda: self.attic())


### PR DESCRIPTION
Comments:

With print_verbose, I wasn't sure whether to use a comma or a percent sign to separate the formatting string from the object to be formatted, but I at least made the existing calls consistent.

In the tests, I switched to using assert_in, as it shows better output when the assertion fails.

I updated the tests to use --keep-daily instead of --daily.

Question:

At the end of run(), one might consider adding two lines in order to force verbose mode when using "prune --dry-run", as otherwise there isn't much point.

```
    args = parser.parse_args(args or ['-h'])
    if argcs.func == do_prune and args.dry_run:
        args.verbose = True
    self.verbose = args.verbose
    update_excludes(args)
    return args.func(args)
```

Not sure.
