### PR TITLE
limit create file permissions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Version 0.14
 - Add MacPorts' path to the default openssl search path (#101)
 - HashIndex improvements, eliminates unnecessary IO on low memory systems.
 - Fix "Number of files" output for attic info. (#124)
+- limit create file permissions so files aren't read while restoring
 
 Version 0.13
 ------------

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -186,6 +186,8 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
 
     def do_extract(self, args):
         """Extract archive contents"""
+        # be restrictive when restoring files, restore permissions later
+        os.umask(0o077)
         repository = self.open_repository(args.archive)
         manifest, key = Manifest.load(repository)
         archive = Archive(repository, key, manifest, args.archive.archive,


### PR DESCRIPTION
Be safe by default, create files so that other users can't read them,
at least until the original permissions are set.

This does have a side effect, if the restore creates directories that aren't included in the restore, the permissions aren't reset.
attic extract archive_file::name nested/stuff
if nested doesn't exist, it will be left with 0700 because it was created to restore files, but wasn't listed as something to restore, where
attic extract archive_file::name nested
would set the permissions to the original permissions.
