### PR TITLE
Fix issue 106 - handle None as empty xattr value in setxattr

### DIFF
--- a/attic/xattr.py
+++ b/attic/xattr.py
@@ -89,7 +89,11 @@ if sys.platform.startswith('linux'):
 
     def setxattr(path, name, value, *, follow_symlinks=True):
         name = os.fsencode(name)
-        value = os.fsencode(value)
+        if value is None:
+            l = 0
+        else:
+            value = os.fsencode(value)
+            l = len(value)
         if isinstance(path, str):
             path = os.fsencode(path)
         if isinstance(path, int):
@@ -98,7 +102,7 @@ if sys.platform.startswith('linux'):
             func = libc.setxattr
         else:
             func = libc.lsetxattr
-        _check(func(path, name, value, len(value), 0), path)
+        _check(func(path, name, value, l, 0), path)
 
 elif sys.platform == 'darwin':
     libc.listxattr.argtypes = (c_char_p, c_char_p, c_size_t, c_int)
@@ -155,7 +159,11 @@ elif sys.platform == 'darwin':
 
     def setxattr(path, name, value, *, follow_symlinks=True):
         name = os.fsencode(name)
-        value = os.fsencode(value)
+        if value is None:
+            l = 0
+        else:
+            value = os.fsencode(value)
+            l = len(value)
         func = libc.setxattr
         flags = 0
         if isinstance(path, str):
@@ -164,7 +172,7 @@ elif sys.platform == 'darwin':
             func = libc.fsetxattr
         elif not follow_symlinks:
             flags = XATTR_NOFOLLOW
-        _check(func(path, name, value, len(value), 0, flags), path)
+        _check(func(path, name, value, l, 0, flags), path)
 
 elif sys.platform.startswith('freebsd'):
     EXTATTR_NAMESPACE_USER = 0x0001
@@ -236,7 +244,11 @@ elif sys.platform.startswith('freebsd'):
 
     def setxattr(path, name, value, *, follow_symlinks=True):
         name = os.fsencode(name)
-        value = os.fsencode(value)
+        if value is None:
+            l = 0
+        else:
+            value = os.fsencode(value)
+            l = len(value)
         if isinstance(path, str):
             path = os.fsencode(path)
         if isinstance(path, int):
@@ -245,7 +257,7 @@ elif sys.platform.startswith('freebsd'):
             func = libc.extattr_set_file
         else:
             func = libc.extattr_set_link
-        _check(func(path, EXTATTR_NAMESPACE_USER, name, value, len(value)), path)
+        _check(func(path, EXTATTR_NAMESPACE_USER, name, value, l), path)
 
 else:
     raise Exception('Unsupported platform: %s' % sys.platform)


### PR DESCRIPTION
Fixes this: https://github.com/jborg/attic/issues/106
## Background:

I was hitting the above issue with attic on my MacOSX system, so I modified the `setxattr` code to see what it was failing on: turns out some other software on the system is setting the xattr `lumberjack.log.archived` with empty values. So it looks like xattrs are allowed to be empty, and it turns out attic can easily be updated to handle that, and to apply those empty values when extracting. (Rather than just to skip them, as in the workaround code someone else put on issue #106.) So I've made that change.
## This change:

`xattr` attribute values can be empty. `getxattr` returns `None` for these,
so the dict from `xattr.get_all` can contain None values, and this is
stored in the archive data.
Handle these None values in setxattr: don't call `os.fsencode` because it
errors on None, and pass None and length 0 to the libc function.

I've chosen to handle None values, rather than change the archive data
to contain empty byte values, since we likely already have people out
there with archive data containing None.

I've tested this locally - it now restores the empty attribute values without error, and this roundtrips correctly when backed up again after extracting.
