### PR TITLE
document that hardlinks and symlinks are supported

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -17,6 +17,7 @@ Which file attributes are preserved?
 
     * Name
     * Contents
+    * Hardlinks and symlinks
     * Time of last modification (nanosecond precision with Python >= 3.3)
     * User ID of owner
     * Group ID of owner


### PR DESCRIPTION
it seems that hardlinks are supported, but were not explicitely documented in the documentation. the FAQ seems like the right place to do this. closes #133.
