### PR TITLE
Add metadata search index for more responsive FUSE

### DIFF
--- a/attic/cache.py
+++ b/attic/cache.py
@@ -156,7 +156,7 @@ class Cache(object):
             data = self.key.decrypt(archive_id, cdata)
             add(archive_id, len(data), len(cdata))
             archive = msgpack.unpackb(data)
-            if archive[b'version'] != 1:
+            if archive[b'version'] not in [1, 2]:
                 raise Exception('Unknown archive metadata version')
             decode_dict(archive, (b'name',))
             print('Analyzing archive:', archive[b'name'])

--- a/attic/testsuite/archive.py
+++ b/attic/testsuite/archive.py
@@ -17,7 +17,7 @@ class MockCache:
 class ChunkBufferTestCase(AtticTestCase):
 
     def test(self):
-        data = [{b'foo': 1}, {b'bar': 2}]
+        data = [{b'path': 1}, {b'path': 2}]
         cache = MockCache()
         key = PlaintextKey()
         chunks = CacheChunkBuffer(cache, key, None)

--- a/setup.py
+++ b/setup.py
@@ -122,5 +122,5 @@ setup(
     scripts=['scripts/attic'],
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    install_requires=['msgpack-python']
+    install_requires=['msgpack-python', 'bintrees']
 )


### PR DESCRIPTION
This adds the construction of a metadata index during archive creation,
which can be used to narrow down the location of particular entries
within the items list. The FUSE mount uses this index to fetch only
those chunks that are relevant to the specific operation instead of
fetching the metadata of the entire archive.

As a result, using FUSE mounts of large archives is consirably more
reponsive. And more importantly, the performance isn't indirectly
proportional to the the archive size anymore. Any bulk operations that
require the full metadata tree anyways (such as running "find" on the
entire archive) are not negatively impacted.

For this to work, the filesystem traversal order had to be changed from
depth-first to breadth-first, which introduces the new metadata version
number 2. Any otherwise unrelated parts of the code and tests that
relied on the previous behavior are adjusted accordingly.
