### PR TITLE
Flexibility and cleanup

### DIFF
--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -13,7 +13,7 @@ from attic import __version__
 from attic.archive import Archive, ArchiveChecker
 from attic.repository import Repository
 from attic.cache import Cache
-from attic.key import key_creator
+from attic.key import key_creator, COMPR_DEFAULT
 from attic.helpers import Error, location_validator, format_time, \
     format_file_mode, ExcludePattern, exclude_path, adjust_patterns, to_localtime, \
     get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
@@ -476,8 +476,11 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                                choices=('none', 'passphrase', 'keyfile'), default='none',
                                help='select encryption method')
         subparser.add_argument('-c', '--compression', dest='compression',
-                               choices=('none', 'zlib', 'lzma'), default='zlib',
-                               help='select compression method')
+                               type=int, default=COMPR_DEFAULT, metavar='METHOD',
+                               help='select compression method (0..19)')
+        subparser.add_argument('-m', '--mac', dest='mac',
+                               type=int, default=None, metavar='METHOD',
+                               help='select hash/mac method (0..3)')
 
         check_epilog = textwrap.dedent("""
         The check command verifies the consistency of a repository and the corresponding

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -13,7 +13,7 @@ from attic import __version__
 from attic.archive import Archive, ArchiveChecker
 from attic.repository import Repository
 from attic.cache import Cache
-from attic.key import key_creator, COMPR_DEFAULT
+from attic.key import key_creator, COMPR_DEFAULT, HASH_DEFAULT, MAC_DEFAULT
 from attic.helpers import Error, location_validator, format_time, \
     format_file_mode, ExcludePattern, exclude_path, adjust_patterns, to_localtime, \
     get_cache_dir, get_keys_dir, format_timedelta, prune_within, prune_split, \
@@ -466,18 +466,18 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         Encryption can be enabled, compression and mac method can be chosen at
         repository init time.
 
-        --compression METHODs (default: zlib level 6):
+        --compression METHODs (default: %02d):
 
         - 00..09  zlib levels 0..9 (0 means no compression, 9 max. compression)
         - 10..19  lzma levels 0..9 (0 means no compression, 9 max. compression)
 
-        --mac METHODs (default: sha256 or hmac-sha256):
+        --mac METHODs (default: %02d or %02d):
 
-        - 0       sha256 (just simple hash, no MAC, faster on 32bit CPU)
-        - 1       sha512-256 (just simple hash, no MAC, faster on 64bit CPU)
-        - 2       hmac-sha256 (HMAC, faster on 32bit CPU)
-        - 3       hmac-sha512-256 (HMAC, faster on 64bit CPU)
-        """)
+        - 00      sha256 (just simple hash, no MAC, faster on 32bit CPU)
+        - 01      sha512-256 (just simple hash, no MAC, faster on 64bit CPU)
+        - 10      hmac-sha256 (HMAC, faster on 32bit CPU)
+        - 11      hmac-sha512-256 (HMAC, faster on 64bit CPU)
+        """ % (COMPR_DEFAULT, HASH_DEFAULT, MAC_DEFAULT))
         subparser = subparsers.add_parser('init', parents=[common_parser],
                                           description=self.do_init.__doc__, epilog=init_epilog,
                                           formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -475,6 +475,9 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         subparser.add_argument('-e', '--encryption', dest='encryption',
                                choices=('none', 'passphrase', 'keyfile'), default='none',
                                help='select encryption method')
+        subparser.add_argument('-c', '--compression', dest='compression',
+                               choices=('zlib', 'lzma'), default='zlib',
+                               help='select compression method')
 
         check_epilog = textwrap.dedent("""
         The check command verifies the consistency of a repository and the corresponding

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -463,7 +463,20 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         init_epilog = textwrap.dedent("""
         This command initializes an empty repository. A repository is a filesystem
         directory containing the deduplicated data from zero or more archives.
-        Encryption can be enabled at repository init time.
+        Encryption can be enabled, compression and mac method can be chosen at
+        repository init time.
+
+        --compression METHODs (default: zlib level 6):
+
+        - 00..09  zlib levels 0..9 (0 means no compression, 9 max. compression)
+        - 10..19  lzma levels 0..9 (0 means no compression, 9 max. compression)
+
+        --mac METHODs (default: sha256 or hmac-sha256):
+
+        - 0       sha256 (just simple hash, no MAC, faster on 32bit CPU)
+        - 1       sha512-256 (just simple hash, no MAC, faster on 64bit CPU)
+        - 2       hmac-sha256 (HMAC, faster on 32bit CPU)
+        - 3       hmac-sha512-256 (HMAC, faster on 64bit CPU)
         """)
         subparser = subparsers.add_parser('init', parents=[common_parser],
                                           description=self.do_init.__doc__, epilog=init_epilog,

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -476,7 +476,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                                choices=('none', 'passphrase', 'keyfile'), default='none',
                                help='select encryption method')
         subparser.add_argument('-c', '--compression', dest='compression',
-                               choices=('zlib', 'lzma'), default='zlib',
+                               choices=('none', 'zlib', 'lzma'), default='zlib',
                                help='select compression method')
 
         check_epilog = textwrap.dedent("""

--- a/attic/key.py
+++ b/attic/key.py
@@ -90,6 +90,16 @@ class LzmaCompressor(CompressorBase):
         return lzma.decompress(data)
 
 
+class NullCompressor(CompressorBase):
+    TYPE = 0x20
+
+    def compress(self, data):
+        return data
+
+    def decompress(self, data):
+        return data
+
+
 def compressor_creator(args):
     if args is None:  # used by unit tests
         return ZlibCompressor.create(args)
@@ -97,6 +107,8 @@ def compressor_creator(args):
         return LzmaCompressor.create(args)
     if args.compression == 'zlib':
         return ZlibCompressor.create(args)
+    if args.compression == 'none':
+        return NullCompressor.create(args)
     raise NotImplemented(args.compression)
 
 
@@ -107,6 +119,8 @@ def compressor_factory(manifest_data):
         return ZlibCompressor()
     if compression_type == LzmaCompressor.TYPE:
         return LzmaCompressor()
+    if compression_type == NullCompressor.TYPE:
+        return NullCompressor()
     raise UnsupportedPayloadError(manifest_data[0])
 
 

--- a/attic/key.py
+++ b/attic/key.py
@@ -514,6 +514,11 @@ def parser03(all_data):  # new & flexible
     meta is a Meta namedtuple and contains all required information about data.
     data is maybe compressed (see meta) and maybe encrypted (see meta).
     """
+    # TODO use Unpacker(..., max_*_len=NOTMORETHANNEEDED) to avoid any memory
+    # allocation issues on untrusted and potentially tampered input data.
+    # Problem: we currently must use older msgpack because pure python impl.
+    # is broken in 0.4.2 < version <= 0.4.5, but this api is only offered by
+    # more recent ones, not by 0.4.2. So, fix here when 0.4.6 is out. :-(
     meta_tuple, data = msgpack.unpackb(all_data[1:])
     meta = Meta(*meta_tuple)
     compressor, crypter, maccer = get_implementations(meta)

--- a/attic/key.py
+++ b/attic/key.py
@@ -64,7 +64,7 @@ class HMAC(hmac.HMAC):
 
 
 class SHA256(object):  # note: can't subclass sha256
-    TYPE = 0x00
+    TYPE = 0
 
     def __init__(self, key, data=b''):
         # signature is like for a MAC, we ignore the key as this is a simple hash
@@ -84,7 +84,7 @@ class SHA256(object):  # note: can't subclass sha256
 
 class SHA512_256(sha512_256):
     """sha512, but digest truncated to 256bit - faster than sha256 on 64bit platforms"""
-    TYPE = 0x01
+    TYPE = 1
 
     def __init__(self, key, data):
         # signature is like for a MAC, we ignore the key as this is a simple hash
@@ -97,7 +97,7 @@ HASH_DEFAULT = SHA256.TYPE
 
 
 class HMAC_SHA256(HMAC):
-    TYPE = 0x02
+    TYPE = 10
 
     def __init__(self, key, data):
         if key is None:
@@ -106,7 +106,7 @@ class HMAC_SHA256(HMAC):
 
 
 class HMAC_SHA512_256(HMAC):
-    TYPE = 0x03
+    TYPE = 11
 
     def __init__(self, key, data):
         if key is None:

--- a/attic/key.py
+++ b/attic/key.py
@@ -27,17 +27,19 @@ class UnsupportedPayloadError(Error):
 
 class sha512_256(object):  # note: can't subclass sha512
     """sha512, but digest truncated to 256bit - faster than sha256 on 64bit platforms"""
+    digest_size = 32
+
     def __init__(self, data=b''):
         self.h = sha512(data)
 
-    def update(self, data):
-        self.h.update(data)
-
     def digest(self):
-        return self.h.digest()[:32]
+        return self.h.digest()[:self.digest_size]
 
     def hexdigest(self):
-        return self.h.hexdigest()[:64]
+        return self.h.hexdigest()[:self.digest_size * 2]
+
+    def __getattr__(self, item):
+        return getattr(self.h, item)
 
 
 class HMAC(hmac.HMAC):

--- a/attic/key.py
+++ b/attic/key.py
@@ -479,37 +479,30 @@ def get_implementations(meta):
     return compressor, crypter, maccer
 
 
-def parser00(all_data):  # legacy, hardcoded
+def legacy_parser(all_data, crypt_type):  # all rather hardcoded
     offset = 1
-    hmac = all_data[offset:offset+32]
-    stored_iv = all_data[offset+32:offset+40]
-    iv = PREFIX + stored_iv
-    data = all_data[offset+40:]
-    meta = Meta(compr_type=6, crypt_type=KeyfileKey.TYPE, mac_type=HMAC_SHA256.TYPE,
+    if crypt_type == PlaintextKey.TYPE:
+        hmac = None
+        iv = stored_iv = None
+        data = all_data[offset:]
+    else:
+        hmac = all_data[offset:offset+32]
+        stored_iv = all_data[offset+32:offset+40]
+        iv = PREFIX + stored_iv
+        data = all_data[offset+40:]
+    meta = Meta(compr_type=6, crypt_type=crypt_type, mac_type=HMAC_SHA256.TYPE,
                 hmac=hmac, iv=iv, stored_iv=stored_iv)
     compressor, crypter, maccer = get_implementations(meta)
     return meta, data, compressor, crypter, maccer
 
-def parser01(all_data):  # legacy, hardcoded
-    offset = 1
-    hmac = all_data[offset:offset+32]
-    stored_iv = all_data[offset+32:offset+40]
-    iv = PREFIX + stored_iv
-    data = all_data[offset+40:]
-    meta = Meta(compr_type=6, crypt_type=PassphraseKey.TYPE, mac_type=HMAC_SHA256.TYPE,
-                hmac=hmac, iv=iv, stored_iv=stored_iv)
-    compressor, crypter, maccer = get_implementations(meta)
-    return meta, data, compressor, crypter, maccer
+def parser00(all_data):
+    return legacy_parser(all_data, KeyfileKey.TYPE)
 
-def parser02(all_data):  # legacy, hardcoded
-    offset = 1
-    hmac = None
-    iv = stored_iv = None
-    data = all_data[offset:]
-    meta = Meta(compr_type=6, crypt_type=PlaintextKey.TYPE, mac_type=SHA256.TYPE,
-                hmac=hmac, iv=iv, stored_iv=stored_iv)
-    compressor, crypter, maccer = get_implementations(meta)
-    return meta, data, compressor, crypter, maccer
+def parser01(all_data):
+    return legacy_parser(all_data, PassphraseKey.TYPE)
+
+def parser02(all_data):
+    return legacy_parser(all_data, PlaintextKey.TYPE)
 
 
 def parser03(all_data):  # new & flexible

--- a/attic/key.py
+++ b/attic/key.py
@@ -451,7 +451,7 @@ crypter_mapping = {
 
 
 maccer_mapping = {
-    # simple hashes, not MACs (but MAC-like signature):
+    # simple hashes, not MACs (but MAC-like class __init__ method signature):
     SHA256.TYPE: SHA256,
     SHA512_256.TYPE: SHA512_256,
     # MACs:

--- a/attic/key.py
+++ b/attic/key.py
@@ -213,8 +213,6 @@ class AESKeyBase(KeyBase):
     affect security but limits the maximum repository capacity to
     only 295 exabytes!
     """
-    PAYLOAD_OVERHEAD = 4 + 32 + 8  # HEADER + HMAC + NONCE, TODO: get rid of this
-
     def id_hash(self, data):
         """Return HMAC hash using the "id" HMAC key
         """

--- a/attic/testsuite/archive.py
+++ b/attic/testsuite/archive.py
@@ -1,7 +1,7 @@
 import msgpack
 from attic.testsuite import AtticTestCase
 from attic.archive import CacheChunkBuffer, RobustUnpacker
-from attic.key import PlaintextKey
+from attic.key import PlaintextKey, ZlibCompressor
 
 
 class MockCache:
@@ -19,7 +19,7 @@ class ChunkBufferTestCase(AtticTestCase):
     def test(self):
         data = [{b'foo': 1}, {b'bar': 2}]
         cache = MockCache()
-        key = PlaintextKey()
+        key = PlaintextKey(ZlibCompressor())
         chunks = CacheChunkBuffer(cache, key, None)
         for d in data:
             chunks.add(d)

--- a/attic/testsuite/archive.py
+++ b/attic/testsuite/archive.py
@@ -1,7 +1,7 @@
 import msgpack
 from attic.testsuite import AtticTestCase
 from attic.archive import CacheChunkBuffer, RobustUnpacker
-from attic.key import PlaintextKey, ZlibCompressor
+from attic.key import PlaintextKey, COMPR_DEFAULT
 
 
 class MockCache:
@@ -16,10 +16,15 @@ class MockCache:
 
 class ChunkBufferTestCase(AtticTestCase):
 
+    class MockArgs(object):
+        repository = None
+        compression = COMPR_DEFAULT
+        mac = None
+
     def test(self):
         data = [{b'foo': 1}, {b'bar': 2}]
         cache = MockCache()
-        key = PlaintextKey(ZlibCompressor())
+        key = PlaintextKey.create(None, self.MockArgs())
         chunks = CacheChunkBuffer(cache, key, None)
         for d in data:
             chunks.add(d)

--- a/attic/testsuite/archiver.py
+++ b/attic/testsuite/archiver.py
@@ -359,8 +359,8 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 hash = sha256(data).digest()
                 if not hash in seen:
                     seen.add(hash)
-                    num_blocks = num_aes_blocks(len(data) - 41)
-                    nonce = bytes_to_long(data[33:41])
+                    num_blocks = num_aes_blocks(len(data) - 4 - 40)
+                    nonce = bytes_to_long(data[4+32:4+40])
                     for counter in range(nonce, nonce + num_blocks):
                         self.assert_not_in(counter, used)
                         used.add(counter)

--- a/attic/testsuite/archiver.py
+++ b/attic/testsuite/archiver.py
@@ -13,6 +13,7 @@ from attic.archive import Archive, ChunkBuffer
 from attic.archiver import Archiver
 from attic.crypto import bytes_to_long, num_aes_blocks
 from attic.helpers import Manifest
+from attic.key import parser
 from attic.remote import RemoteRepository, PathNotAllowed
 from attic.repository import Repository
 from attic.testsuite import AtticTestCase
@@ -359,8 +360,9 @@ class ArchiverTestCase(ArchiverTestCaseBase):
                 hash = sha256(data).digest()
                 if not hash in seen:
                     seen.add(hash)
-                    num_blocks = num_aes_blocks(len(data) - 4 - 40)
-                    nonce = bytes_to_long(data[4+32:4+40])
+                    meta, data, _, _, _ = parser(data)
+                    num_blocks = num_aes_blocks(len(data))
+                    nonce = bytes_to_long(meta.stored_iv)
                     for counter in range(nonce, nonce + num_blocks):
                         self.assert_not_in(counter, used)
                         used.add(counter)

--- a/attic/testsuite/key.py
+++ b/attic/testsuite/key.py
@@ -13,6 +13,7 @@ class KeyTestCase(AtticTestCase):
 
     class MockArgs(object):
         repository = Location(tempfile.mkstemp()[1])
+        compression = 'zlib'
 
     keyfile2_key_file = """
         ATTIC KEY 0000000000000000000000000000000000000000000000000000000000000000

--- a/attic/testsuite/key.py
+++ b/attic/testsuite/key.py
@@ -5,7 +5,7 @@ import tempfile
 from binascii import hexlify
 from attic.crypto import bytes_to_long, num_aes_blocks
 from attic.testsuite import AtticTestCase
-from attic.key import PlaintextKey, PassphraseKey, KeyfileKey
+from attic.key import PlaintextKey, PassphraseKey, KeyfileKey, COMPR_DEFAULT
 from attic.helpers import Location, unhexlify
 
 
@@ -13,7 +13,8 @@ class KeyTestCase(AtticTestCase):
 
     class MockArgs(object):
         repository = Location(tempfile.mkstemp()[1])
-        compression = 'zlib'
+        compression = COMPR_DEFAULT
+        mac = None
 
     keyfile2_key_file = """
         ATTIC KEY 0000000000000000000000000000000000000000000000000000000000000000
@@ -46,7 +47,7 @@ class KeyTestCase(AtticTestCase):
         id = bytes(32)
 
     def test_plaintext(self):
-        key = PlaintextKey.create(None, None)
+        key = PlaintextKey.create(None, self.MockArgs())
         data = b'foo'
         self.assert_equal(hexlify(key.id_hash(data)), b'2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')
         self.assert_equal(data, key.decrypt(key.id_hash(data), key.encrypt(data)))
@@ -79,7 +80,7 @@ class KeyTestCase(AtticTestCase):
 
     def test_passphrase(self):
         os.environ['ATTIC_PASSPHRASE'] = 'test'
-        key = PassphraseKey.create(self.MockRepository(), None)
+        key = PassphraseKey.create(self.MockRepository(), self.MockArgs())
         self.assert_equal(bytes_to_long(key.enc_cipher.iv, 8), 0)
         self.assert_equal(hexlify(key.id_key), b'793b0717f9d8fb01c751a487e9b827897ceea62409870600013fbc6b4d8d7ca6')
         self.assert_equal(hexlify(key.enc_hmac_key), b'b885a05d329a086627412a6142aaeb9f6c54ab7950f996dd65587251f6bc0901')

--- a/attic/testsuite/key.py
+++ b/attic/testsuite/key.py
@@ -64,7 +64,8 @@ class KeyTestCase(AtticTestCase):
         self.assert_equal(key.extract_nonce(manifest2), 1)
         iv = key.extract_nonce(manifest)
         key2 = KeyfileKey.detect(self.MockRepository(), manifest)
-        self.assert_equal(bytes_to_long(key2.enc_cipher.iv, 8), iv + num_aes_blocks(len(manifest) - KeyfileKey.PAYLOAD_OVERHEAD))
+        # we just assume that the payload fits into 1 AES block (which is given for b'XXX').
+        self.assert_equal(bytes_to_long(key2.enc_cipher.iv, 8), iv + 1)
         # Key data sanity check
         self.assert_equal(len(set([key2.id_key, key2.enc_key, key2.enc_hmac_key])), 3)
         self.assert_equal(key2.chunk_seed == 0, False)
@@ -94,7 +95,8 @@ class KeyTestCase(AtticTestCase):
         self.assert_equal(key.extract_nonce(manifest2), 1)
         iv = key.extract_nonce(manifest)
         key2 = PassphraseKey.detect(self.MockRepository(), manifest)
-        self.assert_equal(bytes_to_long(key2.enc_cipher.iv, 8), iv + num_aes_blocks(len(manifest) - PassphraseKey.PAYLOAD_OVERHEAD))
+        # we just assume that the payload fits into 1 AES block (which is given for b'XXX').
+        self.assert_equal(bytes_to_long(key2.enc_cipher.iv, 8), iv + 1)
         self.assert_equal(key.id_key, key2.id_key)
         self.assert_equal(key.enc_hmac_key, key2.enc_hmac_key)
         self.assert_equal(key.enc_key, key2.enc_key)

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,10 @@ elif platform == 'FreeBSD':
 elif platform == 'Darwin':
     ext_modules.append(Extension('attic.platform_darwin', [platform_darwin_source]))
 
+install_requires = ['msgpack-python']
+if sys.version_info < (3, 3):
+    install_requires.append('backports.lzma')
+
 setup(
     name='Attic',
     version=versioneer.get_version(),
@@ -122,5 +126,5 @@ setup(
     scripts=['scripts/attic'],
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    install_requires=['msgpack-python']
+    install_requires=install_requires,
 )


### PR DESCRIPTION
## Flexibility

These changes bring the needed flexibility to support multiple compression levels and algorithms (e.g. zlib all levels (not just 6), and also lzma all levels). It is very easy to add other compression algorithms / levels now.

For better performance, I also added sha512-256 hashing algorithm, which is faster than sha256 on 64bit CPUs.

I implemented the changes in a backwards compatible way, so old repos still work.

usage: attic init --compression=6 --mac=0   # defaults (as before)

The header format itself is now much more flexible due to usage of msgpack there.
E.g. the hmac length is not required to be 32 bytes any more (see aes-gcm, which can only yield up to 16 bytes, see sha512, which could give 64 bytes). Also, the stored IV could be full 16 bytes now. (all not done yet)
## Cleanup

A lot of hardcoded offsets and ranges were replaced by better to read and less fragile meta namedtuple elements.

See also issue #210.
