### PR TITLE
cleanup crypto.pyx, make it easier to adapt to other modes

### DIFF
--- a/attic/crypto.pyx
+++ b/attic/crypto.pyx
@@ -152,7 +152,10 @@ cdef class AES:
         cdef int inl = len(data)
         cdef int ptl = 0
         cdef int outl = 0
-        cdef unsigned char *out = <unsigned char *>malloc(inl)
+        # note: modes that use padding, need up to one extra AES block (16b).
+        # This is what the openssl docs say. I am not sure this is correct,
+        # but OTOH it will not cause any harm if our buffer is a little bigger.
+        cdef unsigned char *out = <unsigned char *>malloc(inl+16)
         if not out:
             raise MemoryError
         try:

--- a/attic/key.py
+++ b/attic/key.py
@@ -144,8 +144,8 @@ class AESKeyBase(KeyBase):
             self.chunk_seed = self.chunk_seed - 0xffffffff - 1
 
     def init_ciphers(self, enc_iv=b''):
-        self.enc_cipher = AES(self.enc_key, enc_iv)
-        self.dec_cipher = AES(self.enc_key)
+        self.enc_cipher = AES(is_encrypt=True, key=self.enc_key, iv=enc_iv)
+        self.dec_cipher = AES(is_encrypt=False, key=self.enc_key)
 
 
 class PassphraseKey(AESKeyBase):
@@ -244,7 +244,7 @@ class KeyfileKey(AESKeyBase):
         assert d[b'version'] == 1
         assert d[b'algorithm'] == b'sha256'
         key = pbkdf2_sha256(passphrase.encode('utf-8'), d[b'salt'], d[b'iterations'], 32)
-        data = AES(key).decrypt(d[b'data'])
+        data = AES(is_encrypt=False, key=key).decrypt(d[b'data'])
         if HMAC(key, data, sha256).digest() != d[b'hash']:
             return None
         return data
@@ -254,7 +254,7 @@ class KeyfileKey(AESKeyBase):
         iterations = 100000
         key = pbkdf2_sha256(passphrase.encode('utf-8'), salt, iterations, 32)
         hash = HMAC(key, data, sha256).digest()
-        cdata = AES(key).encrypt(data)
+        cdata = AES(is_encrypt=True, key=key).encrypt(data)
         d = {
             'version': 1,
             'salt': salt,

--- a/attic/testsuite/crypto.py
+++ b/attic/testsuite/crypto.py
@@ -30,11 +30,15 @@ class CryptoTestCase(AtticTestCase):
     def test_aes(self):
         key = b'X' * 32
         data = b'foo' * 10
-        aes = AES(key)
+        # encrypt
+        aes = AES(is_encrypt=True, key=key)
         self.assert_equal(bytes_to_long(aes.iv, 8), 0)
         cdata = aes.encrypt(data)
         self.assert_equal(hexlify(cdata), b'c6efb702de12498f34a2c2bbc8149e759996d08bf6dc5c610aefc0c3a466')
         self.assert_equal(bytes_to_long(aes.iv, 8), 2)
-        self.assert_not_equal(data, aes.decrypt(cdata))
-        aes.reset(iv=b'\0' * 16)
-        self.assert_equal(data, aes.decrypt(cdata))
+        # decrypt
+        aes = AES(is_encrypt=False, key=key)
+        self.assert_equal(bytes_to_long(aes.iv, 8), 0)
+        pdata = aes.decrypt(cdata)
+        self.assert_equal(data, pdata)
+        self.assert_equal(bytes_to_long(aes.iv, 8), 2)


### PR DESCRIPTION
There were some small issues:

 a) it never called EVP_EncryptFinal_ex.
For CTR mode, this had no visible consequences as EVP_EncryptUpdate already yielded all ciphertext.
For cleanliness and to have correctness even in other modes, the missing call was added.

b) decrypt = encrypt hack
This is a nice hack to abbreviate, but it only works for modes without padding and without authentication.
For cleanliness and to have correctness even in other modes, the missing usage of the decrypt api was added.

c) outl == inl assumption
Again, True for CTR mode, but not for padding or authenticating modes.
Fixed so it computes the ciphertext / plaintext length based on api return values.

Other changes:
As encrypt and decrypt API calls are different even for initialization/reset, added a is_encrypt flag.

Defensive output buffer allocation. Added the length of one extra AES block (16bytes) so it would
work even with padding modes. 16bytes are needed because a full block of padding might get
added when the plaintext was a multiple of aes block size.

These changes are based on some experimental code I did for aes-cbc and aes-gcm.
While we likely won't ever want aes-cbc in attic (maybe gcm though?), I think it is cleaner
to not make too many mode specific assumptions and hacks, but just use the API as it
was meant to be used.
