### PR TITLE
better attic create -v output

### DIFF
--- a/attic/archive.py
+++ b/attic/archive.py
@@ -365,28 +365,33 @@ class Archive:
         acl_get(path, item, st, self.numeric_owner)
         return item
 
-    def process_item(self, path, st):
+    def process_dir(self, path, st):
         item = {b'path': make_path_safe(path)}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)
+        return 'd'  # directory
+
+    def process_fifo(self, path, st):
+        item = {b'path': make_path_safe(path)}
+        item.update(self.stat_attrs(st, path))
+        self.add_item(item)
+        return 'f'  # fifo
 
     def process_dev(self, path, st):
         item = {b'path': make_path_safe(path), b'rdev': st.st_rdev}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)
         if stat.S_ISCHR(st.st_mode):
-            status = 'c'  # char device
+            return 'c'  # char device
         elif stat.S_ISBLK(st.st_mode):
-            status = 'b'  # block device
-        return status
+            return 'b'  # block device
 
     def process_symlink(self, path, st):
         source = os.readlink(path)
         item = {b'path': make_path_safe(path), b'source': source}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)
-        status = 's'  # symlink
-        return status
+        return 's'  # symlink
 
     def process_file(self, path, st, cache):
         status = None

--- a/attic/archive.py
+++ b/attic/archive.py
@@ -374,14 +374,22 @@ class Archive:
         item = {b'path': make_path_safe(path), b'rdev': st.st_rdev}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)
+        if stat.S_ISCHR(st.st_mode):
+            status = 'c'  # char device
+        elif stat.S_ISBLK(st.st_mode):
+            status = 'b'  # block device
+        return status
 
     def process_symlink(self, path, st):
         source = os.readlink(path)
         item = {b'path': make_path_safe(path), b'source': source}
         item.update(self.stat_attrs(st, path))
         self.add_item(item)
+        status = 's'  # symlink
+        return status
 
     def process_file(self, path, st, cache):
+        status = None
         safe_path = make_path_safe(path)
         # Is it a hard link?
         if st.st_nlink > 1:
@@ -390,7 +398,8 @@ class Archive:
                 item = self.stat_attrs(st, path)
                 item.update({b'path': safe_path, b'source': source})
                 self.add_item(item)
-                return
+                status = 'h'  # regular file, hardlink (to already seen inodes)
+                return status
             else:
                 self.hard_links[st.st_ino, st.st_dev] = safe_path
         path_hash = self.key.id_hash(os.path.join(self.cwd, path).encode('utf-8', 'surrogateescape'))
@@ -403,6 +412,9 @@ class Archive:
                     break
             else:
                 chunks = [cache.chunk_incref(id_, self.stats) for id_ in ids]
+                status = 'U'  # regular file, unchanged
+        else:
+            status = 'A'  # regular file, added
         # Only chunkify the file if needed
         if chunks is None:
             with Archive._open_rb(path, st) as fd:
@@ -410,10 +422,12 @@ class Archive:
                 for chunk in self.chunker.chunkify(fd):
                     chunks.append(cache.add_chunk(self.key.id_hash(chunk), chunk, self.stats))
             cache.memorize_file(path_hash, st, [c[0] for c in chunks])
+            status = status or 'M'  # regular file, modified (if not 'A' already)
         item = {b'path': safe_path, b'chunks': chunks}
         item.update(self.stat_attrs(st, path))
         self.stats.nfiles += 1
         self.add_item(item)
+        return status
 
     @staticmethod
     def list_archives(repository, key, manifest, cache=None):

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -166,8 +166,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         elif stat.S_ISDIR(st.st_mode):
             if exclude_caches and is_cachedir(path):
                 return
-            archive.process_item(path, st)
-            status = 'd'  # directory
+            status = archive.process_dir(path, st)
             try:
                 entries = os.listdir(path)
             except OSError as e:
@@ -179,8 +178,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         elif stat.S_ISLNK(st.st_mode):
             status = archive.process_symlink(path, st)
         elif stat.S_ISFIFO(st.st_mode):
-            archive.process_item(path, st)
-            status = 'f'  # fifo
+            status = archive.process_fifo(path, st)
         elif stat.S_ISCHR(st.st_mode) or stat.S_ISBLK(st.st_mode):
             status = archive.process_dev(path, st)
         else:


### PR DESCRIPTION
Added a indicator character to the left for (A)dded, (M)odified, (U)nchanged status
of regular files. Lowercase indicators are for special files.

You may or may not want to use grep -v ^[Ud] to filter out U and d.

Note: this is just relative to the "files" cache. If the files cache were not used (see other PR), this will always say "(A)dded". Is there a better method?

BTW: i noted strange effects when trying this, like one or two files always outputting "A" although they did not change. Just normal files like Desktop/attic.png.
