### PR TITLE
improve on read-only targets, see issue #202

### DIFF
--- a/attic/remote.py
+++ b/attic/remote.py
@@ -157,7 +157,7 @@ class RemoteRepository(object):
                             raise PathNotAllowed(*res)
                         if error == b'ObjectNotFound':
                             raise Repository.ObjectNotFound(res[0], self.location.orig)
-                        raise self.RPCError(error)
+                        raise self.RPCError("%s%r" % (error.decode('ascii'), res))
                     else:
                         yield res
                         if not waiting_for and not calls:

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -138,7 +138,14 @@ class Repository(object):
 
     def prepare_txn(self, transaction_id, do_cleanup=True):
         self._active_txn = True
-        self.lock.upgrade()
+        try:
+            self.lock.upgrade()
+        except UpgradableLock.WriteLockFailed:
+            # if upgrading the lock to exclusive fails, we do not have an
+            # active transaction. this is important for "serve" mode, where
+            # the repository instance lives on - even if exceptions happened.
+            self._active_txn = False
+            raise
         if not self.index:
             self.index = self.open_index(transaction_id)
         if transaction_id is None:


### PR DESCRIPTION
it now fails in the same way for remote r/o targets as for local r/o targets (with a write lock exception).

with a remote target, the Repository instance seems to survive exceptions and thus the wrong self._txn_state lead to the strange behaviour that can be seen in the traceback of issue #202.

i am not completely sure whether this is the best solution, please review.
