### PR TITLE
fix noatime mode, fixes #243

### DIFF
--- a/attic/archive.py
+++ b/attic/archive.py
@@ -429,7 +429,8 @@ class Archive:
             return open(p, 'rb')
 
         def open_noatime_if_owner(p, s):
-            if s.st_uid == euid:
+            if euid == 0 or s.st_uid == euid:
+                # we are root or owner of file
                 return os.fdopen(os.open(p, flags_noatime), 'rb')
             else:
                 return open(p, 'rb')
@@ -442,6 +443,7 @@ class Archive:
                 fo = open(p, 'rb')
                 # Yes, it was -- otherwise the above line would have thrown
                 # another exception.
+                nonlocal euid
                 euid = os.geteuid()
                 # So in future, let's check whether the file is owned by us
                 # before attempting to use O_NOATIME.


### PR DESCRIPTION
added "nonlocal euid" - without this, euid just gets redefined in inner scope instead of assigned to outer scope
added check for euid 0 - if we run as root, we always have permissions (not just if we are file owner)

note: due to caching and OS behaviour on linux, the bug was a bit tricky to reproduce
and also the fix was a bit tricky to test.

one needs strictatime mount option to enfore traditional atime updating.

for repeated tests, always change file contents (e.g. from /dev/urandom) or attic's caching
will prevent that the file gets read ("accessed") again.

check atimes with ls -lu

i could reproduce code was broken and is fixed with this changeset. and root now doesn't touch any atimes.
