### PR TITLE
fix some exception handlers

### DIFF
--- a/attic/archive.py
+++ b/attic/archive.py
@@ -587,7 +587,9 @@ class ArchiveChecker:
                 continue
             try:
                 archive = msgpack.unpackb(data)
-            except:
+            # Ignore exceptions that might be raised when feeding
+            # msgpack with invalid data
+            except (TypeError, ValueError, StopIteration):
                 continue
             if isinstance(archive, dict) and b'items' in archive and b'cmdline' in archive:
                 self.report_progress('Found archive ' + archive[b'name'].decode('utf-8'), error=True)

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -446,7 +446,7 @@ class LoggedIO(object):
         with open(filename, 'rb') as fd:
             try:
                 fd.seek(-self.header_fmt.size, os.SEEK_END)
-            except Exception as e:
+            except OSError as e:
                 # return False if segment file is empty or too small
                 if e.errno == errno.EINVAL:
                     return False


### PR DESCRIPTION
don't catch "Exception" when OSError was meant (otherwise e.errno is not there anyway)
don't use bare "except:" if one can avoid (copied code fragment from similar handler)
