### PR TITLE
catch all Exceptions, transmit traceback back from remote

### DIFF
--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -728,6 +728,9 @@ def main():
     except Error as e:
         archiver.print_error(e.get_message())
         exit_code = e.exit_code
+    except RemoteRepository.RPCError as e:
+        print(e)
+        exit_code = 1
     except KeyboardInterrupt:
         archiver.print_error('Error: Keyboard interrupt')
         exit_code = 1


### PR DESCRIPTION
before this changesets, most informations about exceptions/tracebacks
on the remote side were lost. now they are transmitted and displayed,
together with the remote attic version.
