### PR TITLE
implemented create --progress

### DIFF
--- a/attic/archive.py
+++ b/attic/archive.py
@@ -120,7 +120,7 @@ class Archive:
         """Archive {} already exists"""
 
     def __init__(self, repository, key, manifest, name, cache=None, create=False,
-                 checkpoint_interval=300, numeric_owner=False):
+                 checkpoint_interval=300, numeric_owner=False, progress=False):
         self.cwd = os.getcwd()
         self.key = key
         self.repository = repository
@@ -128,6 +128,8 @@ class Archive:
         self.manifest = manifest
         self.hard_links = {}
         self.stats = Statistics()
+        self.show_progress = progress
+        self.last_progress = time.time()
         self.name = name
         self.checkpoint_interval = checkpoint_interval
         self.numeric_owner = numeric_owner
@@ -174,6 +176,9 @@ class Archive:
             yield item
 
     def add_item(self, item):
+        if self.show_progress and time.time() - self.last_progress > 0.2:
+            self.stats.show_progress(item=item)
+            self.last_progress = time.time()
         self.items_buffer.add(item)
         if time.time() - self.last_checkpoint > self.checkpoint_interval:
             self.write_checkpoint()

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -100,7 +100,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         cache = Cache(repository, key, manifest)
         archive = Archive(repository, key, manifest, args.archive.archive, cache=cache,
                           create=True, checkpoint_interval=args.checkpoint_interval,
-                          numeric_owner=args.numeric_owner)
+                          numeric_owner=args.numeric_owner, progress=args.progress)
         # Add Attic cache dir to inode_skip list
         skip_inodes = set()
         try:
@@ -127,6 +127,8 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
                 restrict_dev = None
             self._process(archive, cache, args.excludes, args.exclude_caches, skip_inodes, path, restrict_dev)
         archive.save()
+        if args.progress:
+            archive.stats.show_progress(final=True)
         if args.stats:
             t = datetime.now()
             diff = t - t0
@@ -532,6 +534,9 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         subparser.add_argument('-s', '--stats', dest='stats',
                                action='store_true', default=False,
                                help='print statistics for the created archive')
+        subparser.add_argument('-p', '--progress', dest='progress',
+                               action='store_true', default=False,
+                               help='print progress while creating the archive')
         subparser.add_argument('-e', '--exclude', dest='excludes',
                                type=ExcludePattern, action='append',
                                metavar="PATTERN", help='exclude paths matching PATTERN')

--- a/attic/helpers.py
+++ b/attic/helpers.py
@@ -167,6 +167,18 @@ class Statistics:
         print('%-15s %20s %20s %20s' % (label, format_file_size(self.osize), format_file_size(self.csize), format_file_size(self.usize)))
         print('All archives:   %20s %20s %20s' % (format_file_size(total_size), format_file_size(total_csize), format_file_size(unique_csize)))
 
+    def show_progress(self, item=None, final=False):
+        if not final:
+            path = remove_surrogates(item[b'path']) if item else ''
+            if len(path) > 43:
+                path = '%s...%s' % (path[:20], path[-20:])
+            msg = '%9s O %9s C %9s D %-43s' % (
+                format_file_size(self.osize), format_file_size(self.csize), format_file_size(self.usize), path)
+        else:
+            msg = ' ' * 79
+        print(msg, end='\r')
+        sys.stdout.flush()
+
 
 def get_keys_dir():
     """Determine where to repository keys and cache"""


### PR DESCRIPTION
shows original, compressed and deduped size plus path name.

output is 79 chars wide, so 80x24 terminal does not wrap/scroll.

long path names are shortened (in a rather simplistic way).

output happens when a new item is started, but not more often than 5/s
(thus, not every pathname is shown)

at the end, the output line is cleared but not scrolled, so it basically vanishes.
