### PR TITLE
Adds a note about the ACCDCC2D signing key to the installation documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,4 +55,6 @@ Standalone binaries
 -------------------
 
 Prebuilt standalone binaries that work on
-most Linux systems can be found :artifacts:`here <>`.
+most Linux systems can be found :artifacts:`here <>`. Please use the 
+`ACCDCC2D <http://pgp.mit.edu/pks/lookup?op=vindex&search=0xA72F8337ACCDCC2D>`_ key to
+verify signatures of the tar archives.


### PR DESCRIPTION
I wasn't able to find information about the key used to sign the standalone binaries mentioned here https://attic-backup.org/installation.html#standalone-binaries
