### PR TITLE
Escape ".." in path regexp properly.

### DIFF
--- a/attic/helpers.py
+++ b/attic/helpers.py
@@ -498,7 +498,7 @@ def remove_surrogates(s, errors='replace'):
     return s.encode('utf-8', errors).decode('utf-8')
 
 
-_safe_re = re.compile('^((..)?/+)+')
+_safe_re = re.compile('^((\.\.)?/+)+')
 
 
 def make_path_safe(path):


### PR DESCRIPTION
Attic stripped the initial component from paths if it was two characters long. This turned out to be due to an unescaped ".." in the make_path_safe regexp.
