### PR TITLE
Documentation for 'attic serve'

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -144,6 +144,14 @@ or::
 
   $ attic init ssh://user@hostname:port/repository.attic
 
+Remote operations over SSH can be automated with SSH keys. You can restrict the
+use of the SSH keypair by prepending a forced command to the SSH public key in
+the remote server's authorized_keys file. Only the forced command will be run
+when the key authenticates a connection. This example will start attic in server
+mode, and limit the attic server to a specific filesystem path::
+
+  command="attic serve --restrict-to-path /repository.attic" ssh-rsa AAAAB3[...]
+
 If it is not possible to install |project_name| on the remote host, 
 it is still possible to use the remote host to store a repository by
 mounting the remote filesystem, for example, using sshfs::

--- a/docs/update_usage.sh
+++ b/docs/update_usage.sh
@@ -2,7 +2,7 @@
 if [ ! -d usage ]; then
   mkdir usage
 fi
-for cmd in change-passphrase check create delete extract info init list mount prune; do
+for cmd in change-passphrase check create delete extract info init list mount prune serve; do
   FILENAME="usage/$cmd.rst.inc"
   LINE=`echo -n attic $cmd | tr 'a-z- ' '-'`
   echo -e ".. _attic_$cmd:\n" > $FILENAME

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -167,3 +167,14 @@ Examples
     New passphrase: 
     Enter same passphrase again: 
     Key file "/home/USER/.attic/keys/tmp_encrypted_repo" updated
+
+.. include:: usage/serve.rst.inc
+
+Examples
+~~~~~~~~
+::
+
+    # Allow an SSH keypair to only run attic, and only have access to repo.attic
+    # This will help to secure an automated remote backup system.
+    $ cat ~/.ssh/authorized_keys
+    command="attic serve --restrict-to-path /path/to/repo.attic" ssh-rsa AAAAB3[...]


### PR DESCRIPTION
Here is some documentation of how to use `attic serve` and its option `--restrict-to-path` to secure the use of an SSH keypair. This is an essential feature of any SSH-based automated system and I'm sure others have wondered if attic offers this feature.

This patch gives an explanation and example to the "Remote repositories" section of `quickstart.rst` and some usage info and another example to `usage.rst`.

I'm not sure the changes I made to `update_usage.sh` are correct. Based on a comment in `archiver.py`, `serve` seems to be a special case for the documentation system. As a result, there is no description generated for usage.rst. But this patch at least gives the usage info and an example for the usage page.