### PR TITLE
use posix_fadvise to avoid spoiling the OS cache

### DIFF
--- a/attic/_chunker.c
+++ b/attic/_chunker.c
@@ -78,8 +78,9 @@ typedef struct {
     int window_size, chunk_mask, min_size;
     size_t buf_size;
     uint32_t *table;
-    uint8_t *data;
+    uint8_t *data, *read_buf;
     PyObject *fd;
+    int fh;
     int done, eof;
     size_t remaining, bytes_read, bytes_yielded, position, last;
 } Chunker;
@@ -94,15 +95,17 @@ chunker_init(int window_size, int chunk_mask, int min_size, uint32_t seed)
     c->table = buzhash_init_table(seed);
     c->buf_size = 10 * 1024 * 1024;
     c->data = malloc(c->buf_size);
+    c->read_buf = malloc(c->buf_size);
     return c;
 }
 
 static void
-chunker_set_fd(Chunker *c, PyObject *fd)
+chunker_set_fd(Chunker *c, PyObject *fd, int fh)
 {
     Py_XDECREF(c->fd);
     c->fd = fd;
     Py_INCREF(fd);
+    c->fh = fh;
     c->done = 0;
     c->remaining = 0;
     c->bytes_read = 0;
@@ -118,6 +121,7 @@ chunker_free(Chunker *c)
     Py_XDECREF(c->fd);
     free(c->table);
     free(c->data);
+    free(c->read_buf);
     free(c);
 }
 
@@ -133,20 +137,40 @@ chunker_fill(Chunker *c)
     if(c->eof || n == 0) {
         return 1;
     }
-    data = PyObject_CallMethod(c->fd, "read", "i", n);
-    if(!data) {
-        return 0;
-    }
-    n = PyBytes_Size(data);
-    if(n) {
-        memcpy(c->data + c->position + c->remaining, PyBytes_AsString(data), n);
-        c->remaining += n;
-        c->bytes_read += n;
+    if(c->fh >= 0) {
+        // if we have a os-level file descriptor, use os-level API
+        n = read(c->fh, c->read_buf, n);
+        if(n > 0) {
+            memcpy(c->data + c->position + c->remaining, c->read_buf, n);
+            c->remaining += n;
+            c->bytes_read += n;
+        }
+        else
+        if(n == 0) {
+            c->eof = 1;
+        }
+        else {
+            // some error happened
+            return 0;
+        }
     }
     else {
-        c->eof = 1;
+        // no os-level file descriptor, use Python file object API
+        data = PyObject_CallMethod(c->fd, "read", "i", n);
+        if(!data) {
+            return 0;
+        }
+        n = PyBytes_Size(data);
+        if(n) {
+            memcpy(c->data + c->position + c->remaining, PyBytes_AsString(data), n);
+            c->remaining += n;
+            c->bytes_read += n;
+        }
+        else {
+            c->eof = 1;
+        }
+        Py_DECREF(data);
     }
-    Py_DECREF(data);
     return 1;
 }
 

--- a/attic/archive.py
+++ b/attic/archive.py
@@ -429,7 +429,8 @@ class Archive:
             return open(p, 'rb')
 
         def open_noatime_if_owner(p, s):
-            if s.st_uid == euid:
+            if euid == 0 or s.st_uid == euid:
+                # we are root or owner of file
                 return os.fdopen(os.open(p, flags_noatime), 'rb')
             else:
                 return open(p, 'rb')
@@ -442,6 +443,7 @@ class Archive:
                 fo = open(p, 'rb')
                 # Yes, it was -- otherwise the above line would have thrown
                 # another exception.
+                nonlocal euid
                 euid = os.geteuid()
                 # So in future, let's check whether the file is owned by us
                 # before attempting to use O_NOATIME.

--- a/attic/chunker.pyx
+++ b/attic/chunker.pyx
@@ -9,7 +9,7 @@ cdef extern from "_chunker.c":
     ctypedef struct _Chunker "Chunker":
         pass
     _Chunker *chunker_init(int window_size, int chunk_mask, int min_size, uint32_t seed)
-    void chunker_set_fd(_Chunker *chunker, object fd)
+    void chunker_set_fd(_Chunker *chunker, object f, int fd)
     void chunker_free(_Chunker *chunker)
     object chunker_process(_Chunker *chunker)
     uint32_t *buzhash_init_table(uint32_t seed)
@@ -23,8 +23,15 @@ cdef class Chunker:
     def __cinit__(self, window_size, chunk_mask, min_size, seed):
         self.chunker = chunker_init(window_size, chunk_mask, min_size, seed & 0xffffffff)
 
-    def chunkify(self, fd):
-        chunker_set_fd(self.chunker, fd)
+    def chunkify(self, fd, fh=-1):
+        """
+        Cut a file into chunks.
+
+        :param fd: Python file object
+        :param fh: OS-level file handle (if available),
+                   defaults to -1 which means not to use OS-level fd.
+        """
+        chunker_set_fd(self.chunker, fd, fh)
         return self
 
     def __dealloc__(self):

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -555,6 +555,10 @@ class LoggedIO(object):
         header = self.header_no_crc_fmt.pack(size, TAG_PUT)
         crc = self.crc_fmt.pack(crc32(data, crc32(id, crc32(header))) & 0xffffffff)
         fd.write(b''.join((crc, header, id, data)))
+        if hasattr(os, 'posix_fadvise'):  # python >= 3.3, only on UNIX
+            # tell the OS that it does not need to cache what we just wrote,
+            # avoids spoiling the cache for the OS and other processes.
+            os.posix_fadvise(fd.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
         self.offset += size
         return self.segment, offset
 

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -555,10 +555,6 @@ class LoggedIO(object):
         header = self.header_no_crc_fmt.pack(size, TAG_PUT)
         crc = self.crc_fmt.pack(crc32(data, crc32(id, crc32(header))) & 0xffffffff)
         fd.write(b''.join((crc, header, id, data)))
-        if hasattr(os, 'posix_fadvise'):  # python >= 3.3, only on UNIX
-            # tell the OS that it does not need to cache what we just wrote,
-            # avoids spoiling the cache for the OS and other processes.
-            os.posix_fadvise(fd.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
         self.offset += size
         return self.segment, offset
 
@@ -581,6 +577,10 @@ class LoggedIO(object):
         if self._write_fd:
             self.segment += 1
             self.offset = 0
-            os.fsync(self._write_fd)
+            os.fsync(self._write_fd.fileno())
+            if hasattr(os, 'posix_fadvise'):  # python >= 3.3, only on UNIX
+                # tell the OS that it does not need to cache what we just wrote,
+                # avoids spoiling the cache for the OS and other processes.
+                os.posix_fadvise(self._write_fd.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
             self._write_fd.close()
             self._write_fd = None


### PR DESCRIPTION
this is on-top of / includes PR #244.

for "attic create", neither the backup input file reads nor the repo file writes will spoil the cache any more.
