### PR TITLE
Fix archive metadata parsing with missing microseconds

### DIFF
--- a/attic/archive.py
+++ b/attic/archive.py
@@ -163,8 +163,11 @@ class Archive:
     @property
     def ts(self):
         """Timestamp of archive creation in UTC"""
-        t, f = self.metadata[b'time'].split('.', 1)
-        return datetime.strptime(t, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc) + timedelta(seconds=float('.' + f))
+        t = self.metadata[b'time'].split('.', 1)
+        dt = datetime.strptime(t[0], '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc)
+        if len(t) > 1:
+            dt += timedelta(seconds=float('.' + t[1]))
+        return dt
 
     def __repr__(self):
         return 'Archive(%r)' % self.name

--- a/attic/testsuite/archive.py
+++ b/attic/testsuite/archive.py
@@ -1,7 +1,10 @@
 import msgpack
 from attic.testsuite import AtticTestCase
-from attic.archive import CacheChunkBuffer, RobustUnpacker
+from attic.testsuite.mock import Mock
+from attic.archive import Archive, CacheChunkBuffer, RobustUnpacker
 from attic.key import PlaintextKey
+from attic.helpers import Manifest
+from datetime import datetime, timezone
 
 
 class MockCache:
@@ -12,6 +15,27 @@ class MockCache:
     def add_chunk(self, id, data, stats=None):
         self.objects[id] = data
         return id, len(data), len(data)
+
+
+class ArchiveTimestampTestCase(AtticTestCase):
+
+    def _test_timestamp_parsing(self, isoformat, expected):
+        repository = Mock()
+        key = PlaintextKey()
+        manifest = Manifest(repository, key)
+        a = Archive(repository, key, manifest, 'test', create=True)
+        a.metadata = {b'time': isoformat}
+        self.assert_equal(a.ts, expected)
+
+    def test_with_microseconds(self):
+        self._test_timestamp_parsing(
+            '1970-01-01T00:00:01.000001',
+            datetime(1970, 1, 1, 0, 0, 1, 1, timezone.utc))
+
+    def test_without_microseconds(self):
+        self._test_timestamp_parsing(
+            '1970-01-01T00:00:01',
+            datetime(1970, 1, 1, 0, 0, 1, 0, timezone.utc))
 
 
 class ChunkBufferTestCase(AtticTestCase):


### PR DESCRIPTION
datetime.datetime.isoformat() elides microseconds from its string output if the microseconds are zero. The parsing in archive.Archive.ts() needs to be able to handle this.