### PR TITLE
use sys.platform everywhere, fixes #188

### DIFF
--- a/attic/platform.py
+++ b/attic/platform.py
@@ -1,12 +1,10 @@
-import os
+import sys
 
-platform = os.uname()[0]
-
-if platform == 'Linux':
+if sys.platform.startswith('linux'):
     from attic.platform_linux import acl_get, acl_set, API_VERSION
-elif platform == 'FreeBSD':
+elif sys.platform.startswith('freebsd'):
     from attic.platform_freebsd import acl_get, acl_set, API_VERSION
-elif platform == 'Darwin':
+elif sys.platform == 'darwin':
     from attic.platform_darwin import acl_get, acl_set, API_VERSION
 else:
     API_VERSION = 2

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ versioneer.versionfile_build = 'attic/_version.py'
 versioneer.tag_prefix = ''
 versioneer.parentdir_prefix = 'Attic-' # dirname like 'myproject-1.2.0'
 
-platform = os.uname()[0]
-
 min_python = (3, 2)
 if sys.version_info < min_python:
     print("Attic requires Python %d.%d or later" % min_python)
@@ -89,11 +87,11 @@ ext_modules = [
     Extension('attic.chunker', [chunker_source]),
     Extension('attic.hashindex', [hashindex_source])
 ]
-if platform == 'Linux':
+if sys.platform.startswith('linux'):
     ext_modules.append(Extension('attic.platform_linux', [platform_linux_source], libraries=['acl']))
-elif platform == 'FreeBSD':
+elif sys.platform.startswith('freebsd'):
     ext_modules.append(Extension('attic.platform_freebsd', [platform_freebsd_source]))
-elif platform == 'Darwin':
+elif sys.platform == 'darwin':
     ext_modules.append(Extension('attic.platform_darwin', [platform_darwin_source]))
 
 setup(


### PR DESCRIPTION
os.uname is UNIX-only, sys.platform is portable.

note:
- this doesn't implicate attic will now work on windows.
- windows is untested / unsupported and there might be a lot of other issues left.
- attic's xattr module already used sys.platform, so this is better for internal consistency also.