### PR TITLE
Honor nodump flag

### DIFF
--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -158,6 +158,9 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         # Ignore unix sockets
         if stat.S_ISSOCK(st.st_mode):
             return
+        # Ignore if nodump flag set
+        if st.st_flags and stat.UF_NODUMP(st.st_flags):
+            return
         self.print_verbose(remove_surrogates(path))
         if stat.S_ISREG(st.st_mode):
             try:

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -159,7 +159,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         if stat.S_ISSOCK(st.st_mode):
             return
         # Ignore if nodump flag set
-        if st.st_flags and stat.UF_NODUMP(st.st_flags):
+        if st.st_flags and (st.st_flags & stat.UF_NODUMP):
             return
         self.print_verbose(remove_surrogates(path))
         if stat.S_ISREG(st.st_mode):

--- a/attic/archiver.py
+++ b/attic/archiver.py
@@ -21,6 +21,7 @@ from attic.helpers import Error, location_validator, format_time, \
     is_cachedir, bigint_to_int
 from attic.remote import RepositoryServer, RemoteRepository
 
+has_lchflags = hasattr(os, 'lchflags')
 
 class Archiver:
 
@@ -159,7 +160,7 @@ Type "Yes I am sure" if you understand this and want to continue.\n""")
         if stat.S_ISSOCK(st.st_mode):
             return
         # Ignore if nodump flag set
-        if st.st_flags and (st.st_flags & stat.UF_NODUMP):
+        if has_lchflags and (st.st_flags & stat.UF_NODUMP):
             return
         self.print_verbose(remove_surrogates(path))
         if stat.S_ISREG(st.st_mode):


### PR DESCRIPTION
On BSD systems (NetBSD, FreeBSD, MacOS) the "nodump" flag should cause files to not be backed up.   This change implements that.

Tested on NetBSD 6.1 and Ubuntu.
