### PR TITLE
Tiny fixes: printf error messages and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ env
 .tox
 hashindex.c
 chunker.c
+crypto.c
+platform_linux.c
 *.egg-info
 *.pyc
 *.pyo

--- a/attic/_hashindex.c
+++ b/attic/_hashindex.c
@@ -145,7 +145,7 @@ hashindex_read(const char *path)
             EPRINTF_PATH(path, "fread failed");
         }
         else {
-            EPRINTF_MSG_PATH(path, "failed to read %ld bytes", sizeof(HashHeader));
+            EPRINTF_MSG_PATH(path, "failed to read %ld bytes", (long) sizeof(HashHeader));
         }
         goto fail;
     }
@@ -185,7 +185,7 @@ hashindex_read(const char *path)
             EPRINTF_PATH(path, "fread failed");
         }
         else {
-            EPRINTF_MSG_PATH(path, "failed to read %ld bytes", length);
+            EPRINTF_MSG_PATH(path, "failed to read %lld bytes", (long long) buckets_length);
         }
         free(index->buckets);
         free(index);


### PR DESCRIPTION
Two tiny fixes, please merge :).

hashindex: Fix printf size specifiers in error messages
gitignore: all cython generated files
