### PR TITLE
Optimization: asynchronous writeback

### DIFF
--- a/attic/repository.py
+++ b/attic/repository.py
@@ -598,7 +598,8 @@ class FsyncWorker(object):
     def __init__(self):
         self.channel = Channel()
         self.exception = None
-        thread = threading.Thread(target=self._run, daemon=True)
+        thread = threading.Thread(target=self._run)
+        thread.daemon = True
         thread.start()
 
     def _run(self):

--- a/attic/repository.py
+++ b/attic/repository.py
@@ -603,10 +603,10 @@ class FsyncWorker(object):
         thread.start()
 
     def _run(self):
-        while True: # worker thread loop
+        while True:  # worker thread loop
             task = self.channel.get()
-            if task == None:
-                break # thread shutdown requested
+            if task is None:
+                break  # thread shutdown requested
             try:
                 task()
             except Exception as e:
@@ -619,7 +619,7 @@ class FsyncWorker(object):
                 os.fsync(fd)
             finally:
                 fd.close()
-        self.flush() # raise any pending exception
+        self.flush()  # raise any pending exception
         self.channel.put(task)
 
     def flush(self):
@@ -632,7 +632,7 @@ class FsyncWorker(object):
             pass
         self.channel.put(task)
 
-        if self.exception != None:
+        if self.exception is not None:
             e = self.exception
             self.exception = None
             raise e
@@ -641,7 +641,7 @@ class FsyncWorker(object):
         try:
             self.flush()
         finally:
-            self.channel.put(None) # tell thread to shutdown
+            self.channel.put(None)  # tell thread to shutdown
 
 class Channel(object):
     """A blocking channel, like in CSP or Go.
@@ -659,4 +659,4 @@ class Channel(object):
 
     def put(self, item):
         self.q.put(item)
-        self.q.join() # wait for task_done(), in reader thread
+        self.q.join()  # wait for task_done(), in reader thread


### PR DESCRIPTION
fsync() after each segment write is suboptimal :).  It means you stop (cpu) processing to wait for the physical disk write.  And the default segment size is 5MB. (I noticed bup avoids this issue by writing pack files of 1GB by default :).

Improvements will vary depending disk/cpu speed.  (I guess the worst case was when they were evenly matched).
- Writing 65M on SheevaPlug "NAS" went from 47s to 45s.
- 920M on desktop HDD (read from SSD) went from 68s to 45s
