### PR TITLE
Use environment variable to set the tmp directory

### DIFF
--- a/attic/helpers.py
+++ b/attic/helpers.py
@@ -179,6 +179,11 @@ def get_cache_dir():
                           os.path.join(os.path.expanduser('~'), '.cache', 'attic'))
 
 
+def get_tmp_dir():
+    """Determine where to save temporary files"""
+    return os.environ.get('ATTIC_TMP_DIR', None)
+
+
 def to_localtime(ts):
     """Convert datetime object from UTC to local time zone"""
     return datetime(*time.localtime((ts - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())[:6])

--- a/attic/remote.py
+++ b/attic/remote.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 
 from .hashindex import NSIndex
-from .helpers import Error, IntegrityError
+from .helpers import Error, IntegrityError, get_tmp_dir
 from .repository import Repository
 
 BUFSIZE = 10 * 1024 * 1024
@@ -267,7 +267,8 @@ class RepositoryCache:
         self.cleanup()
 
     def initialize(self):
-        self.tmppath = tempfile.mkdtemp()
+        tmp_dir = get_tmp_dir()
+        self.tmppath = tempfile.mkdtemp(dir=tmp_dir)
         self.index = NSIndex()
         self.data_fd = open(os.path.join(self.tmppath, 'data'), 'a+b')
 


### PR DESCRIPTION
I had a problem with running attic on a system where root partition was very small. When attic was verifying archives it was using ~160MB of disk space which was way more than the allowed 100MB.
