### PR TITLE
setup.py: seek `/opt/pkg` (pkgsrc OS X) for openssl.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def detect_openssl(prefixes):
                     return prefix
 
 
-possible_openssl_prefixes = ['/usr', '/usr/local', '/usr/local/opt/openssl', '/usr/local/ssl', '/usr/local/openssl', '/usr/local/attic', '/opt/local']
+possible_openssl_prefixes = ['/usr', '/usr/local', '/usr/local/opt/openssl', '/usr/local/ssl', '/usr/local/openssl', '/usr/local/attic', '/opt/local', '/opt/pkg']
 if os.environ.get('ATTIC_OPENSSL_PREFIX'):
     possible_openssl_prefixes.insert(0, os.environ.get('ATTIC_OPENSSL_PREFIX'))
 ssl_prefix = detect_openssl(possible_openssl_prefixes)


### PR DESCRIPTION
Add `/opt/pkg` (used by pkgsrc on Mac OS X) to
possible openssl header path.

> from 2015Q2 onwards the prefix has changed to `/opt/pkg`
> in order to be compatible with El Capitan's
> "System Integrity Protection" feature.

-- [pkgsrc.joynet.com](http://pkgsrc.joyent.com/install-on-osx/)

---

 setup.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
