### PR TITLE
Update installation instruction in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Backups mountable as filesystems
 What do I need?
 ---------------
 Attic requires Python 3.2 or above to work. Besides Python, Attic also requires 
-msgpack-python and sufficiently recent OpenSSL (>= 1.0.0).
-In order to mount archives as filesystems, llfuse is required.
+msgpack-python, libacl headers (available as libacl1-dev on Ubuntu) and sufficiently
+recent OpenSSL (>= 1.0.0). In order to mount archives as filesystems, llfuse is required.
 
 How do I install it?
 --------------------


### PR DESCRIPTION
On a pristine Ubuntu system, you also need libacl1-dev in order
for the installation (via `pip install`) to succeed.

A future commit should also update the fact that you need some
build tools (compiler, etc) setup, which can be installed on Ubuntu
via the `build-essential` pkg.